### PR TITLE
Stream pg_dump into psql instead of staging dump.sql on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ GitHub property 'github.ref' used to determine the branch name.
 #### 'github_actor' (required)
 GitHub property 'github.actor' to capture who is initiating the action.
 
-#### 'sql_dump' (optional)
-Set to false by default. Used for debugging. Upload dump.sql file as dump-sql artifact to workflow.
-
 #### 'aws_access_key' (required)
 Access key for Aws upload.
 

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,6 @@ inputs:
   github_actor:
     description: 'GitHub actor property'
     required: true
-  sql_dump:
-    description: 'dump.sql file upload as dump-sql artifact'
-    default: false
-    required: false
   aws_access_key:
     description: 'AWS Access Key (Required if no aws-actions/configure-aws-credentials)'
     required: false
@@ -80,14 +76,4 @@ runs:
         SOURCE_DB: ${{ inputs.source_database_name }}
         ACTION: ${{ inputs.branch_action }}
         DB_CLUSTER: ${{ inputs.database_cluster }}
-        SQL_DUMP: ${{ inputs.sql_dump }}
       run: bash ${{ github.action_path }}/script.sh
-
-    - name: Upload Dump.sql
-      if: inputs.sql_dump == 'true' && (success() || failure())
-      uses: actions/upload-artifact@v4
-      with:
-        path: dump.sql
-        name: dump-sql
-        retention-days: 1
-        if-no-files-found: ignore

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,7 @@ runs:
         SOURCE_DB: ${{ inputs.source_database_name }}
         ACTION: ${{ inputs.branch_action }}
         DB_CLUSTER: ${{ inputs.database_cluster }}
+        SQL_DUMP: ${{ inputs.sql_dump }}
       run: bash ${{ github.action_path }}/script.sh
 
     - name: Upload Dump.sql

--- a/script.sh
+++ b/script.sh
@@ -22,6 +22,10 @@ get_database_connection_settings() {
     export PGPASSWORD=$DBPASSWORD
 }
 
+dump_source_db() {
+    pg_dump --exclude-table-data=audit.audit_log_* --exclude-table-data=audit.page_view_* --exclude-table=public.data_change_staging* --disable-triggers --no-owner --no-privileges -h $DBHOST -U $DBUSERNAME -d $SOURCE_DB
+}
+
 get_database_connection_settings $SECRET_ID
 
 if [ $ACTION = "Delete" ]; then
@@ -64,9 +68,15 @@ elif [[ $ACTION = "Create" ]] || [[ $ACTION = "Recreate" ]]; then
         psql -h $DBHOST -U $DBUSERNAME -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$DATABASE';"
         dropdb --if-exists -h $DBHOST -U $DBUSERNAME $DATABASE
         createdb --owner=dev_role -h $DBHOST -U $DBUSERNAME $DATABASE --template=template0 --lc-collate=en_US.utf8 --lc-ctype=en_US.utf8 --encoding=UTF-8
-        pg_dump --exclude-table-data=audit.audit_log_* --exclude-table-data=audit.page_view_* --exclude-table=public.data_change_staging* --disable-triggers --no-owner --no-privileges -h $DBHOST -U $DBUSERNAME -d $SOURCE_DB > dump.sql
-        sed -i '1s/^/SET ROLE dev_role;\n/' dump.sql
-        psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f dump.sql -b
+        if [ "$SQL_DUMP" = "true" ]; then
+            # dump.sql is uploaded as an artifact, so it has to be written to disk
+            dump_source_db > dump.sql
+            sed -i '1s/^/SET ROLE dev_role;\n/' dump.sql
+            psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f dump.sql -b
+        else
+            # stream into the target db instead: the dump no longer fits on the runner's disk
+            { echo "SET ROLE dev_role;"; dump_source_db; } | psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f - -b
+        fi
         psql -h $DBHOST -U $DBUSERNAME -d control_center -c "insert into log.branch_database (database_name, created_by_user, source_database) values ('$DATABASE', '$USERNAME', '$SOURCE_DB');" -b
         psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -c "CREATE EVENT TRIGGER trigger_alter_ownership ON ddl_command_end when tag in ('CREATE TABLE', 'CREATE VIEW', 'CREATE MATERIALIZED VIEW', 'CREATE FUNCTION', 'CREATE INDEX') EXECUTE PROCEDURE db_admin.alter_ownership();" -b
         psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -c "GRANT CREATE ON DATABASE \"$DATABASE\" TO dev_role, patriot_pay_deploy_user;" -b

--- a/script.sh
+++ b/script.sh
@@ -43,8 +43,6 @@ elif [[ $ACTION = "Create" ]] || [[ $ACTION = "Recreate" ]]; then
     dbExists=$(psql -U $DBUSERNAME -h $DBHOST -d postgres -qtAX -c "SELECT EXISTS(SELECT 1 AS result FROM pg_database WHERE datname='$DATABASE');")
     dbPrimaryComment=$(psql -qtAX -h $DBHOST -d postgres -U $DBUSERNAME -c "SELECT EXISTS(SELECT 1 AS result FROM pg_database WHERE datname = '$DATABASE' AND shobj_description( oid, 'pg_database') = 'primary');")
 
-    rm -f dump.sql
-
     # set error to exit script and errors on any part of pipe to fail
     set -eo pipefail
 
@@ -68,15 +66,8 @@ elif [[ $ACTION = "Create" ]] || [[ $ACTION = "Recreate" ]]; then
         psql -h $DBHOST -U $DBUSERNAME -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$DATABASE';"
         dropdb --if-exists -h $DBHOST -U $DBUSERNAME $DATABASE
         createdb --owner=dev_role -h $DBHOST -U $DBUSERNAME $DATABASE --template=template0 --lc-collate=en_US.utf8 --lc-ctype=en_US.utf8 --encoding=UTF-8
-        if [ "$SQL_DUMP" = "true" ]; then
-            # dump.sql is uploaded as an artifact, so it has to be written to disk
-            dump_source_db > dump.sql
-            sed -i '1s/^/SET ROLE dev_role;\n/' dump.sql
-            psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f dump.sql -b
-        else
-            # stream into the target db instead: the dump no longer fits on the runner's disk
-            { echo "SET ROLE dev_role;"; dump_source_db; } | psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f - -b
-        fi
+        # SET ROLE first so restored objects end up owned by dev_role
+        { echo "SET ROLE dev_role;"; dump_source_db; } | psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f - -b
         psql -h $DBHOST -U $DBUSERNAME -d control_center -c "insert into log.branch_database (database_name, created_by_user, source_database) values ('$DATABASE', '$USERNAME', '$SOURCE_DB');" -b
         psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -c "CREATE EVENT TRIGGER trigger_alter_ownership ON ddl_command_end when tag in ('CREATE TABLE', 'CREATE VIEW', 'CREATE MATERIALIZED VIEW', 'CREATE FUNCTION', 'CREATE INDEX') EXECUTE PROCEDURE db_admin.alter_ownership();" -b
         psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -c "GRANT CREATE ON DATABASE \"$DATABASE\" TO dev_role, patriot_pay_deploy_user;" -b


### PR DESCRIPTION
## Problem

`Create`/`Recreate` jobs on `psidev-full-arm64` fail intermittently with `exit code 130` and a `cancelled` run. On 2026-08-10 there were 11 such failures — and one success. The runner pod carries the verdict:

```
podReason: "Evicted"
podMessage: "The node was low on resource: ephemeral-storage.
             Threshold quantity: 16095747097, available: 15087392Ki."
DisruptionTarget → reason: "TerminationByKubelet"
```

kubelet evicts the pod, the runner dies, the step takes a SIGINT (130), and GitHub reports the run as cancelled.

## It is a race, and the margin is a few percent

`node_filesystem_avail_bytes` on `/local` (kubelet's nodefs) for a failed run and a successful one, same workload, same source database, 40 minutes apart:

```
        EVICTED (node 10.42.8.134)        SUCCEEDED (node 10.42.12.8)
18:46   92.4GB  ← job starts             19:26   88.3GB  ← job starts
18:50   61.9GB                           19:30   61.9GB
18:54   41.3GB                           19:34   44.6GB
18:58   24.1GB                           19:38   28.3GB
18:59   evicted at the 16.1GB threshold  19:40   22.7GB  ← low-water mark
19:00   92.4GB  ← pod killed             19:42   54.1GB  ← +31.4GB reclaimed
                                         19:56   91.9GB  ← job done
```

Both nodes are identical — every node in the pool reports the same `102334Mi` capacity — and both runs trace the same curve. The successful one bottomed out **6.6GB above the eviction threshold**. The evicted one missed that same finish line by roughly a minute.

The `22.7 → 54.1GB` jump at 19:41 is `sed -i` completing: it writes a full second copy of the dump and then unlinks the original, handing back 31.4GB in one go. The restore output starts at 19:41:11, which matches exactly.

That gives the numbers behind the failure:

- `dump.sql` is **~31.4GB** — the amount reclaimed when the original is unlinked
- `sed -i` is not an in-place edit, so the peak is **~63GB, two full copies at once**
- usable headroom is **~76GB** (92.4GB free at start, minus the 16.1GB threshold)

A peak that consumes 83% of the available headroom is a coin flip on every run, decided by whether `sed` finishes before kubelet notices.

## Change

Pipe `pg_dump` straight into `psql`. Nothing touches the disk; the data lives in the pipe's 64KB kernel buffer, with backpressure pausing `pg_dump` whenever `psql` falls behind. Both copies disappear, and with them the race.

The `SET ROLE dev_role;` line that `sed` prepended (added in #18 to fix object ownership) is echoed at the head of the stream instead:

```bash
{ echo "SET ROLE dev_role;"; dump_source_db; } | psql -h $DBHOST -U $DBUSERNAME -d $DATABASE -f - -b
```

`psql` receives byte-identical input to the sed-patched file, so ownership behaviour is unchanged. The reason this couldn't be done before is that `sed -i` needs a file — a brace group solves the same problem on a stream.

The `sql_dump` artifact path is removed rather than kept as an alternate branch, per review. No caller has ever set it to `true`: all four consumers (`PatriotSoftware`, `Time`, `Time.United`, `TaxEventsService`) just plumb through a `workflow_dispatch` input that defaults to `false`. So the input, the `Upload Dump.sql` step, the now-dead `rm -f dump.sql` and the README entry go with it.

## Tradeoff worth accepting deliberately

**`pg_dump` will hold its snapshot on `patriot_pay` for longer.** `pg_dump` always runs inside a single `REPEATABLE READ` transaction — there is no flag to disable it, and the consistency is not optional for a full dump with foreign keys. Today the snapshot's lifetime is bounded by the dump phase: 14m34s on the successful run above, out of 28m43s total. Streaming means `pg_dump` can only finish as fast as `psql` consumes, so the snapshot spans roughly the whole job — call it double.

A longer-lived snapshot holds back vacuum on the source, so `patriot_pay` accumulates somewhat more dead-tuple bloat per branch-db run, and concurrent runs compound it. The volume looks modest — around 6 branch-db jobs a day in `PatriotSoftware`, occasionally overlapping — but that is inferred from run history, not measured on the database. Worth a look at `pg_stat_database` and `n_dead_tup`/`last_autovacuum` on the hot tables if anyone wants it quantified.

If that cost turns out to matter, the option that removes both the disk pressure and the snapshot is `createdb --template=patriot_pay` — a server-side file copy, no dump at all. It needs zero other sessions connected to `patriot_pay` for the duration, trading a few minutes of unavailability on the master-branch database against a longer held snapshot. Different enough to deserve its own discussion.

Two smaller costs:

- No partial retry. Previously a failed restore could be re-run against the existing `dump.sql`; now any failure re-runs both phases.
- Nothing to inspect after a bad restore. That is what `sql_dump` nominally existed for, though it was never used.

## Upside beyond the race

- Disk consumption stops scaling with database size. At 31.4GB the dump already needs 83% of the headroom; it does not have far to grow before the job stops succeeding at all.
- **~126GB less disk I/O per run.** The current path writes the dump (31.4GB), then reads and rewrites it for `sed` (62.8GB), then reads it back for `psql` (31.4GB) — all of it through a gp3 volume at 125 MB/s baseline, all of it pure overhead. Streaming moves none of it.
- Shorter wall clock. The phases run back to back today (14m34s dump+sed, then ~14min restore, 28m43s total); overlapped, the total should approach the longer phase rather than their sum.

## Testing

`bash -n script.sh` passes. **Not yet exercised against a real database.** Worth a `Recreate` on a throwaway branch db before this reaches everyone.

Note that the old path does still succeed sometimes — the 19:26 run above completed fine on `9d4ed39`. So this is not unblocking a hard outage; it is removing a coin flip.

## Rollout — read before merging

`release-version.yml` runs on every push to `main` and `semver-bump-action` tags the commit and **force-moves the major tag**. `commit-message` is not passed to it, so the bump is always patch. Merging therefore ships immediately to every consumer:

```
v1.2.17 created, v1 force-moved to the merge commit
```

There is no separate "move the tag when ready" step. If that is not wanted, the merge should wait, or `release-version.yml` should be taught to honour `#major` (`commit-message: ${{ github.event.head_commit.message }}`) so this can go out as `v2` and leave `v1` where it is.

Rollback is one call:

```bash
gh api -X PATCH repos/patriotsoftware/branch-db-action/git/refs/tags/v1 \
  -f sha=9d4ed39d8be0009b1ec5f8b40142c07950f7826a -F force=true
```

Once `v1` moves, these four workflows emit `Unexpected input(s) 'sql_dump'` until their pass-through is dropped — a warning, not a failure:

- `SynergyDataSystems/PatriotSoftware` — `.github/workflows/110-db-dev-branch-deploy.yml`
- `SynergyDataSystems/PatriotSoftware.Time` — `.github/workflows/branch-db.yml`
- `SynergyDataSystems/PatriotSoftware.Time.United` — `.github/workflows/branch-db.yml`
- `SynergyDataSystems/PatriotSoftware.TaxEventsService` — `.github/workflows/branch-db-action.yml`

Worth knowing that the other three currently have a clean run history, so they are the ones with something to lose here.

## Related

The infrastructure gap is separate and still worth closing: no pod in `runnerset.values.yaml` declares `ephemeral-storage` requests or limits, and `work` is an `emptyDir` with no `sizeLimit`. Every runner is BestEffort on disk, so a heavy job silently takes out whatever shares its node instead of failing with a clear error.
